### PR TITLE
improving chat history and UI

### DIFF
--- a/frontend/features/recording.mjs
+++ b/frontend/features/recording.mjs
@@ -119,34 +119,17 @@ async function getAudioDuration(audioBlob) {
     });
 }
 
-const MAX_VISIBLE_MESSAGES = 2;
-
-function removeOldMessages() {
+function fadeOutAllMessages() {
     const { chatContainer } = appState.domElements;
-    const messages = chatContainer.querySelectorAll('.chat-message:not(.fade-out)');
-    while (messages.length > MAX_VISIBLE_MESSAGES) {
-        const oldest = messages[0];
-        oldest.classList.add('fade-out');
-        oldest.addEventListener('animationend', () => oldest.remove(), { once: true });
-        // Update NodeList reference manually
-        break;
-    }
-}
-
-function trimVisibleMessages() {
-    const { chatContainer } = appState.domElements;
-    let visible = chatContainer.querySelectorAll('.chat-message:not(.fade-out)');
-    while (visible.length > MAX_VISIBLE_MESSAGES) {
-        const oldest = visible[0];
-        oldest.classList.add('fade-out');
-        oldest.addEventListener('animationend', () => oldest.remove(), { once: true });
-        visible = chatContainer.querySelectorAll('.chat-message:not(.fade-out)');
+    const visible = chatContainer.querySelectorAll('.chat-message:not(.fade-out)');
+    for (const msg of visible) {
+        msg.classList.add('fade-out');
+        msg.addEventListener('animationend', () => msg.remove(), { once: true });
     }
 }
 
 function appendChatMessage(role, text) {
     const { chatContainer } = appState.domElements;
-    trimVisibleMessages();
     const msgEl = document.createElement('div');
     msgEl.classList.add('chat-message', role);
     msgEl.textContent = text;
@@ -177,7 +160,7 @@ function drainWordQueue() {
     if (currentAssistantMessage) {
         currentAssistantMessage.textContent += word;
     }
-    const delay = word.trim() ? 30 : 10;
+    const delay = word.trim() ? 60 : 20;
     setTimeout(drainWordQueue, delay);
 }
 
@@ -224,6 +207,7 @@ export async function sendAudioToServer() {
                 const { type, data, error } = e.data;
                 switch (type) {
                     case "TRANSCRIPTION":
+                        fadeOutAllMessages();
                         currentUserText = data.text;
                         appendChatMessage("user", data.text);
                         break;


### PR DESCRIPTION
## Summary

Integra el Vercel AI SDK (`ai` + `@ai-sdk/google` + `@ai-sdk/openai`) reemplazando los SDKs directos, convierte el endpoint `/message` a SSE para streamear la respuesta del LLM palabra por palabra al frontend, agrega historial de chat stateless (max 5 mensajes), y muestra los mensajes en pantalla con animación de streaming y transiciones suaves.

## Test plan

- [ ] `cd backend && npm install && node --check index.mjs`
- [ ] `cd frontend && npm install && npm run build`
- [ ] Probar flujo completo: grabar → transcripción → texto streameado → audio

https://claude.ai/code/session_01FJwYnpeocbQ3i39GZiPwD9